### PR TITLE
Approving pets

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -1,0 +1,5 @@
+class AdminApplicationsController < ApplicationController
+  def show
+    @application = Application.find(params[:id])
+  end
+end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -32,7 +32,10 @@ class PetsController < ApplicationController
 
   def update
     pet = Pet.find(params[:id])
-    if pet.update(pet_params)
+    if params[:approved]
+      pet.update(adoptable: false)
+      redirect_to "/admin/applications/#{params[:application_id]}"
+    elsif pet.update(pet_params)
       redirect_to "/pets/#{pet.id}"
     else
       redirect_to "/pets/#{pet.id}/edit"

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -1,0 +1,11 @@
+<% @application.pets.each do |pet| %>
+  <div id="pet-<%= pet.id %>">
+    <% if pet.adoptable %>
+      <h3><%= pet.name %></h3>
+      <%= button_to "Approve", "/pets/#{pet.id}", params: {application_id: @application.id, approved: true}, method: :patch, local: true %>
+    <% else %>
+      <h3><%= pet.name %></h3>
+      <p>Approved!</p>
+    <% end %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   get '/applications/new', to: 'applications#new'
   get '/applications/:id', to: 'applications#show'
   post '/applications', to: 'applications#create'
-  
-  get '/admin/shelters', to: 'admin_shelters#index'  
+
+  get '/admin/shelters', to: 'admin_shelters#index'
+  get '/admin/applications/:id', to: 'admin_applications#show'
 end

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'admin_applications show page' do
+  describe 'as a visitor' do
+    describe 'when i visit an admin_application show page' do
+      it 'for every pet, i see a button to approve the application for that specific pet' do
+        application = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
+        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+        pet_1 = application.pets.create(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application.pets.create(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = Pet.create(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+
+        visit "/admin/applications/#{application.id}"
+
+        within "#pet-#{pet_1.id}" do
+          expect(page).to have_button("Approve Application for this Pet")
+        end
+
+        within "#pet-#{pet_2.id}" do
+          expect(page).to have_button("Approve Application for this Pet")
+        end
+
+        within "#pet-#{pet_3.id}" do
+          expect(page).to have_button("Approve Application for this Pet")
+          click_button "Approve Application for this Pet"
+        end
+
+        expect(current_path).to eq("/admin/applications/#{application.id}")
+
+        within "#pet-#{pet_3.id}" do
+          expect(page).not_to have_button("Approve Application for this Pet")
+          expect(page).to have_content("Approved!")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -6,29 +6,29 @@ RSpec.describe 'admin_applications show page' do
       it 'for every pet, i see a button to approve the application for that specific pet' do
         application = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
         shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
-        pet_1 = application.pets.create(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
-        pet_2 = application.pets.create(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
-        pet_3 = Pet.create(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_1 = application.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = application.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
 
         visit "/admin/applications/#{application.id}"
 
         within "#pet-#{pet_1.id}" do
-          expect(page).to have_button("Approve Application for this Pet")
+          expect(page).to have_button("Approve")
         end
 
         within "#pet-#{pet_2.id}" do
-          expect(page).to have_button("Approve Application for this Pet")
+          expect(page).to have_button("Approve")
         end
 
         within "#pet-#{pet_3.id}" do
-          expect(page).to have_button("Approve Application for this Pet")
-          click_button "Approve Application for this Pet"
+          expect(page).to have_button("Approve")
+          click_button "Approve"
         end
 
         expect(current_path).to eq("/admin/applications/#{application.id}")
 
         within "#pet-#{pet_3.id}" do
-          expect(page).not_to have_button("Approve Application for this Pet")
+          expect(page).not_to have_button("Approve")
           expect(page).to have_content("Approved!")
         end
       end


### PR DESCRIPTION
User story 15 complete. This branch accomplishes the following:

-creates an `admin_application#show` page, where for each pet on the application, there is a button to "Approve" the pet, which updates the pet's `:adoptable` attribute so that it can no longer be approved. The user is then redirected back to the same `admin_application#show` page and next to the pet that was approved, there is no longer an "Approve" button but only an indicator showing that the pet was Approved.