### PR TITLE
refactor: update admin_applications#show page pet approval buttons so…

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -18,6 +18,13 @@ class ApplicationsController < ApplicationController
     end
   end
 
+  def update
+    application = Application.find(params[:application_id])
+    application.approved_pet_ids << params[:pet_id].to_i
+    application.save
+    redirect_to "/admin/applications/#{params[:application_id]}"
+  end
+
   private
   def application_params
     params.permit(:name, :address, :city, :state, :zipcode, :description, :status)

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -32,10 +32,7 @@ class PetsController < ApplicationController
 
   def update
     pet = Pet.find(params[:id])
-    if params[:approved]
-      pet.update(adoptable: false)
-      redirect_to "/admin/applications/#{params[:application_id]}"
-    elsif pet.update(pet_params)
+    if pet.update(pet_params)
       redirect_to "/pets/#{pet.id}"
     else
       redirect_to "/pets/#{pet.id}/edit"

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -1,11 +1,11 @@
 <% @application.pets.each do |pet| %>
   <div id="pet-<%= pet.id %>">
-    <% if pet.adoptable %>
-      <h3><%= pet.name %></h3>
-      <%= button_to "Approve", "/pets/#{pet.id}", params: {application_id: @application.id, approved: true}, method: :patch, local: true %>
-    <% else %>
+    <% if @application.approved_pet_ids.include?(pet.id.to_s) %>
       <h3><%= pet.name %></h3>
       <p>Approved!</p>
+    <% else %>
+      <h3><%= pet.name %></h3>
+      <%= button_to "Approve", "/applications/#{@application.id}", params: {application_id: @application.id, pet_id: pet.id}, method: :patch, local: true %>
     <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   get '/applications/new', to: 'applications#new'
   get '/applications/:id', to: 'applications#show'
   post '/applications', to: 'applications#create'
+  patch '/applications/:id', to: 'applications#update'
 
   get '/admin/shelters', to: 'admin_shelters#index'
   get '/admin/applications/:id', to: 'admin_applications#show'

--- a/db/migrate/20220403001142_add_columns_to_applications.rb
+++ b/db/migrate/20220403001142_add_columns_to_applications.rb
@@ -1,0 +1,6 @@
+class AddColumnsToApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applications, :approved_pet_ids, :text, array: true, default: []
+    add_column :applications, :rejected_pet_ids, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_02_203144) do
+ActiveRecord::Schema.define(version: 2022_04_03_001142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 2022_04_02_203144) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "approved_pet_ids", default: [], array: true
+    t.text "rejected_pet_ids", default: [], array: true
   end
 
   create_table "pets", force: :cascade do |t|


### PR DESCRIPTION
I updated the logic for pet approval on a given application so that some given pet can be approved on more than one application. 

To accomplish this, I ran a migration to add a new column to the Application table called `approved_pet_ids`, which is an array. This way, the approval is saved to the application and not to the pet as I had coded it initially. 