### PR TITLE
Reject pet application

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,10 +19,17 @@ class ApplicationsController < ApplicationController
   end
 
   def update
-    application = Application.find(params[:application_id])
-    application.approved_pet_ids << params[:pet_id].to_i
-    application.save
-    redirect_to "/admin/applications/#{params[:application_id]}"
+    if params[:approval]
+      application = Application.find(params[:application_id])
+      application.approved_pet_ids << params[:pet_id]
+      application.save
+      redirect_to "/admin/applications/#{params[:application_id]}"
+    elsif params[:rejection]
+      application = Application.find(params[:application_id])
+      application.rejected_pet_ids << params[:pet_id]
+      application.save
+      redirect_to "/admin/applications/#{params[:application_id]}"
+    end
   end
 
   private

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -3,9 +3,13 @@
     <% if @application.approved_pet_ids.include?(pet.id.to_s) %>
       <h3><%= pet.name %></h3>
       <p>Approved!</p>
+    <% elsif @application.rejected_pet_ids.include?(pet.id.to_s) %>
+      <h3><%= pet.name %></h3>
+      <p>Rejected!</p>
     <% else %>
       <h3><%= pet.name %></h3>
-      <%= button_to "Approve", "/applications/#{@application.id}", params: {application_id: @application.id, pet_id: pet.id}, method: :patch, local: true %>
+      <%= button_to "Approve", "/applications/#{@application.id}", params: {approval: true, application_id: @application.id, pet_id: pet.id}, method: :patch, local: true %>
+      <%= button_to "Reject", "/applications/#{@application.id}", params: {rejection: true, application_id: @application.id, pet_id: pet.id}, method: :patch, local: true %>
     <% end %>
   </div>
 <% end %>

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe 'admin_applications show page' do
       it 'approval and rejection for one application does not affect other applications' do
         application_1 = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
         shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
-        pet_1 = application.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
-        pet_2 = application.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
-        pet_3 = application.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_1 = application_1.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application_1.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = application_1.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
         application_2 = pet_1.applications.create!(name: 'James', address: '1259 N Clarkson St.', city: 'Denver', state: 'CO', zipcode: '80218', description: "Love dogs!", status: 'In-progress')
         application_3 = pet_2.applications.create!(name: 'Ian', address: '4690 S Garrison St.', city: 'Denver', state: 'CO', zipcode: '80123', description: "Love dogs!", status: 'In-progress')
 
@@ -121,6 +121,8 @@ RSpec.describe 'admin_applications show page' do
           expect(page).not_to have_content("Approved!")
           expect(page).not_to have_content("Rejected!")
         end
+
+        visit "/admin/applications/#{application_3.id}"
 
         within "#pet-#{pet_2.id}" do
           expect(page).to have_button("Approve")

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -62,6 +62,73 @@ RSpec.describe 'admin_applications show page' do
           expect(page).to have_content("Rejected!")
         end
       end
+
+      it 'application and rejection buttons work together' do
+        application = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
+        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+        pet_1 = application.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = application.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+
+        visit "/admin/applications/#{application.id}"
+
+        within "#pet-#{pet_1.id}" do
+          click_button "Approve"
+        end
+
+        within "#pet-#{pet_2.id}" do
+          click_button "Reject"
+        end
+
+        within "#pet-#{pet_1.id}" do
+          expect(page).to have_content("Approved!")
+        end
+
+        within "#pet-#{pet_2.id}" do
+          expect(page).to have_content("Rejected!")
+        end
+
+        within "#pet-#{pet_3.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+        end
+      end
+
+      it 'approval and rejection for one application does not affect other applications' do
+        application_1 = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
+        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+        pet_1 = application.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = application.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        application_2 = pet_1.applications.create!(name: 'James', address: '1259 N Clarkson St.', city: 'Denver', state: 'CO', zipcode: '80218', description: "Love dogs!", status: 'In-progress')
+        application_3 = pet_2.applications.create!(name: 'Ian', address: '4690 S Garrison St.', city: 'Denver', state: 'CO', zipcode: '80123', description: "Love dogs!", status: 'In-progress')
+
+        visit "/admin/applications/#{application_1.id}"
+
+        within "#pet-#{pet_1.id}" do
+          click_button "Approve"
+        end
+
+        within "#pet-#{pet_2.id}" do
+          click_button "Reject"
+        end
+
+        visit "/admin/applications/#{application_2.id}"
+
+        within "#pet-#{pet_1.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+          expect(page).not_to have_content("Approved!")
+          expect(page).not_to have_content("Rejected!")
+        end
+
+        within "#pet-#{pet_2.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+          expect(page).not_to have_content("Approved!")
+          expect(page).not_to have_content("Rejected!")
+        end
+      end
     end
   end
 end

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -32,6 +32,36 @@ RSpec.describe 'admin_applications show page' do
           expect(page).to have_content("Approved!")
         end
       end
+
+      it 'for every pet, i see a button to reject the application for that specific pet' do
+        application = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'In-progress')
+        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+        pet_1 = application.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_2 = application.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_3 = application.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+
+        visit "/admin/applications/#{application.id}"
+
+        within "#pet-#{pet_1.id}" do
+          expect(page).to have_button("Reject")
+        end
+
+        within "#pet-#{pet_2.id}" do
+          expect(page).to have_button("Reject")
+        end
+
+        within "#pet-#{pet_3.id}" do
+          expect(page).to have_button("Reject")
+          click_button "Reject"
+        end
+
+        expect(current_path).to eq("/admin/applications/#{application.id}")
+
+        within "#pet-#{pet_3.id}" do
+          expect(page).not_to have_button("Reject")
+          expect(page).to have_content("Rejected!")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
User stories 13 and 14 complete. This branch accomplishes the following: 

-create rejection button for all pets on a given `admin_application#show` page, which works with existing data to offer user the ability to either approve or reject some specific pet on any given application 
-confirm that the approval and/or rejection of some given pet for some given application does not affect the approval/rejection of that same pet on some other application