### PR TITLE
Admin shelters show page links

### DIFF
--- a/app/controllers/admin_shelters_controller.rb
+++ b/app/controllers/admin_shelters_controller.rb
@@ -3,4 +3,8 @@ class AdminSheltersController < ApplicationController
     @shelters = Shelter.order_reverse_alphabetically
     @pending_shelters = Shelter.with_pending_applications
   end
+
+  def show
+    @shelter = Shelter.find(params[:id])
+  end
 end

--- a/app/views/admin_shelters/index.html.erb
+++ b/app/views/admin_shelters/index.html.erb
@@ -1,5 +1,7 @@
 <% @shelters.each do |shelter| %>
-  <h1><%= shelter.name %><h1>
+<div id="shelter-<%= shelter.id %>">
+  <h1><%= link_to "#{shelter.name}", "/admin/shelters/#{shelter.id}" %><h1>
+</div>
 <% end %>
 
 <div id="pending_shelters">

--- a/app/views/admin_shelters/show.html.erb
+++ b/app/views/admin_shelters/show.html.erb
@@ -1,0 +1,1 @@
+<%= @shelter.name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,5 +44,6 @@ Rails.application.routes.draw do
   patch '/applications/:id', to: 'applications#update'
 
   get '/admin/shelters', to: 'admin_shelters#index'
+  get '/admin/shelters/:id', to: 'admin_shelters#show'
   get '/admin/applications/:id', to: 'admin_applications#show'
 end

--- a/spec/features/admins/shelters/index_spec.rb
+++ b/spec/features/admins/shelters/index_spec.rb
@@ -48,8 +48,12 @@ RSpec.describe 'admin_shelters index page' do
 
         within "#shelter-#{shelter_1.id}" do
           click_link "#{shelter_1.name}"
-          expect(current_path).to eq("/admin/shelters/#{shelter_1.id}")
         end
+
+        expect(current_path).to eq("/admin/shelters/#{shelter_1.id}")
+        expect(page).to have_content("#{shelter_1.name}")
+        expect(page).not_to have_content("#{shelter_2.name}")
+        expect(page).not_to have_content("#{shelter_3.name}")
       end
     end
   end

--- a/spec/features/admins/shelters/index_spec.rb
+++ b/spec/features/admins/shelters/index_spec.rb
@@ -34,6 +34,23 @@ RSpec.describe 'admin_shelters index page' do
           expect(page).not_to have_content(shelter_3.name)
         end
       end
+
+      it 'i see that all names are links to show pages' do
+        shelter_1 = Shelter.create!(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+        shelter_2 = Shelter.create!(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+        shelter_3 = Shelter.create!(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+
+        visit "/admin/shelters"
+
+        expect(page).to have_link("#{shelter_1.name}")
+        expect(page).to have_link("#{shelter_2.name}")
+        expect(page).to have_link("#{shelter_3.name}")
+
+        within "#shelter-#{shelter_1.id}" do
+          click_link "#{shelter_1.name}"
+          expect(current_path).to eq("/admin/shelters/#{shelter_1.id}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
User story 6 complete. This branch accomplishes the following: 

-every shelter name on the `admin_shelters#index` page is now a link to that shelter's `admin_shelters#show` page