### PR TITLE
Pets not adoptable

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -11,6 +11,7 @@ class AdminApplicationsController < ApplicationController
     end
     if application.all_pets_approved?
       application.update(status: "Approved")
+      application.pets.each {|pet| pet.update(adoptable: false)}
     elsif application.any_pets_rejected? && application.all_pets_have_ruling?
       application.update(status: "Rejected")
     end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -9,9 +9,6 @@ class PetsController < ApplicationController
 
   def show
     @pet = Pet.find(params[:id])
-    if @pet.approved_application?
-      @pet.update(adoptable: false)
-    end
   end
 
   def new
@@ -20,7 +17,6 @@ class PetsController < ApplicationController
 
   def create
     pet = Pet.new(pet_params)
-
     if pet.save
       redirect_to "/shelters/#{pet_params[:shelter_id]}/pets"
     else

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -11,7 +11,6 @@ class SheltersController < ApplicationController
 
   def pets
     @shelter = Shelter.find(params[:shelter_id])
-
     if params[:sort] == 'alphabetical'
       @shelter_pets = @shelter.alphabetical_pets
     elsif params[:age]
@@ -30,7 +29,6 @@ class SheltersController < ApplicationController
 
   def create
     shelter = Shelter.new(shelter_params)
-
     if shelter.save
       redirect_to '/shelters'
     else

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -12,4 +12,8 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
+
+  def has_any_approved_applications?
+    applications.where(status: "Approved").count > 0
+  end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -12,8 +12,4 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
-
-  def approved_application?
-    applications.any? {|application| application.status == "Approved"}
-  end
 end

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -8,6 +8,9 @@
     <% elsif application_pet.rejected? %>
       <h3><%= application_pet.pet.name %></h3>
       <p>Rejected!</p>
+    <% elsif application_pet.pet.has_any_approved_applications? %>
+      <h3>This pet has already been approved for adoption on another application.</h3>
+      <%= button_to "Reject", "/admin/applications/#{@application.id}", params: {status: :rejected, application_pet_id: application_pet.id}, method: :patch, local: true %>
     <% else %>
       <h3><%= application_pet.pet.name %></h3>
       <%= button_to "Approve", "/admin/applications/#{@application.id}", params: {status: :approved, application_pet_id: application_pet.id}, method: :patch, local: true %>

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -251,19 +251,19 @@ RSpec.describe 'admin_applications show page' do
         within "#pet-#{pet_1.id}" do
           expect(page).not_to have_button("Approve")
           expect(page).to have_button("Reject")
-          expect(page).to have_content("This pet has already been approved for adoption.")
+          expect(page).to have_content("This pet has already been approved for adoption on another application.")
         end
 
         within "#pet-#{pet_2.id}" do
           expect(page).not_to have_button("Approve")
           expect(page).to have_button("Reject")
-          expect(page).to have_content("This pet has already been approved for adoption.")
+          expect(page).to have_content("This pet has already been approved for adoption on another application.")
         end
 
         within "#pet-#{pet_3.id}" do
           expect(page).not_to have_button("Approve")
           expect(page).to have_button("Reject")
-          expect(page).to have_content("This pet has already been approved for adoption.")
+          expect(page).to have_content("This pet has already been approved for adoption on another application.")
         end
       end
     end

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'admin_applications show page' do
         within "#pet-#{pet_3.id}" do
           click_button "Approve"
         end
-
+        
         visit "/pets/#{pet_1.id}"
 
         expect(page).to have_content("false")

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe 'admin_applications show page' do
         ApplicationPet.create!(pet: pet_2, application: application_2)
         ApplicationPet.create!(pet: pet_3, application: application_2)
 
-        visit "/admin/applications/#{application_2.id}"
+        visit "/admin/applications/#{application_1.id}"
 
         within "#pet-#{pet_1.id}" do
           click_button "Approve"
@@ -246,6 +246,7 @@ RSpec.describe 'admin_applications show page' do
         end
 
         visit "/admin/applications/#{application_2.id}"
+        # save_and_open_page
 
         within "#pet-#{pet_1.id}" do
           expect(page).not_to have_button("Approve")

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -40,5 +40,22 @@ RSpec.describe Pet, type: :model do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
       end
     end
+
+    describe '.has_any_approved_applications?' do
+      it 'returns true if any of the pets applications are approved' do
+        application_1 = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'Approved')
+        application_2 = Application.create!(name: 'James', address: '1259 N Clarkson St.', city: 'Denver', state: 'CO', zipcode: '80218', description: "I'm great with dogs.", status: 'In-progress')
+        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+        pet_4 = application_1.pets.create!(name: 'Scrappy', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_5 = application_1.pets.create!(name: 'Sparky', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        pet_6 = application_2.pets.create!(name: 'Spot', age: 1, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+        ApplicationPet.create!(pet: pet_4, application: application_2)
+        ApplicationPet.create!(pet: pet_5, application: application_2)
+
+        expect(pet_4.has_any_approved_applications?).to eq(true)
+        expect(pet_5.has_any_approved_applications?).to eq(true)
+        expect(pet_6.has_any_approved_applications?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -40,20 +40,5 @@ RSpec.describe Pet, type: :model do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
       end
     end
-
-    describe '.approved_application?' do
-      it 'returns true if the pet is on an application that has been approved' do
-        application_1 = Application.create!(name: 'Chris', address: '505 Main St.', city: 'Denver', state: 'CO', zipcode: '80205', description: "I'm great with dogs.", status: 'Approved')
-        application_2 = Application.create!(name: 'James', address: '1259 N Clarkson St.', city: 'Denver', state: 'CO', zipcode: '80218', description: "I'm great with dogs.", status: 'Pending')
-        shelter = Shelter.create(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
-        pet_4 = application_1.pets.create!(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true, shelter_id: shelter.id)
-        pet_5 = application_2.pets.create!(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true, shelter_id: shelter.id)
-        pet_6 = application_1.pets.create!(name: 'Ann', breed: 'ragdoll', age: 3, adoptable: false, shelter_id: shelter.id)
-
-        expect(pet_4.approved_application?).to eq(true)
-        expect(pet_5.approved_application?).to eq(false)
-        expect(pet_6.approved_application?).to eq(true)
-      end
-    end
   end
 end


### PR DESCRIPTION
User stories 9 and 10 complete. This branch accomplishes the following:

-refactors the logic to make pets not adoptable when an application has been approved so that this takes place for all pets on an application as soon as the application has been approved
-creates an instance method for the `pet` model called `has_any_approved_applications?` which returns true if the count of some pet's applications where the application's status is `approved` is greater than 0
-displays the message "This pet has already been approved for adoption on another application" on some admin_application#show page for some pet if it is already associated with another application that has been approved