### PR TITLE
Final refactor

### DIFF
--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -70,6 +70,8 @@ class Shelter < ApplicationRecord
   end
 
   def self.make_address_readable(shelter_id)
-    find_by_sql("SELECT id, CONCAT(address,' ',city,', ',state,' ',zip_code) AS address FROM shelters WHERE id=#{shelter_id}").first.address
+    if find(shelter_id).address
+      find_by_sql("SELECT id, CONCAT(address,' ',city,', ',state,' ',zip_code) AS address FROM shelters WHERE id=#{shelter_id}").first.address
+    end
   end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -60,9 +60,15 @@ class Shelter < ApplicationRecord
   end
 
   def action_required_applications
-    pets.joins(:application_pets, :applications)
-    .select("applications.*")
-    .where("application_pets.status = 0 AND applications.status = 'Pending'")
+    action_required = []
+    action_required_pets.each do |pet|
+      pet.application_pets.each do |application_pet|
+        if Application.find(application_pet.application_id).status == "Pending"
+          action_required << Application.find(application_pet.application_id)
+        end
+      end
+    end
+    action_required
   end
 
   def adopted_pet_count

--- a/spec/features/admins/applications/show_spec.rb
+++ b/spec/features/admins/applications/show_spec.rb
@@ -246,7 +246,6 @@ RSpec.describe 'admin_applications show page' do
         end
 
         visit "/admin/applications/#{application_2.id}"
-        # save_and_open_page
 
         within "#pet-#{pet_1.id}" do
           expect(page).not_to have_button("Approve")

--- a/spec/features/admins/shelters/show_spec.rb
+++ b/spec/features/admins/shelters/show_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'admin_shelters show page' do
 
         it 'i see the shelters name and full address' do
           shelter = Shelter.create(name: 'Mystery Building', address: "22 Acacia Ave.", city: 'New York', state: "NY", zip_code: "10501", foster_program: false, rank: 9)
-          
+
           visit "/admin/shelters/#{shelter.id}"
 
           expect(page).to have_content("Mystery Building")

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Shelter, type: :model do
         ApplicationPet.where(pet: pet_5, application: application_1).first.update(status: :approved)
         ApplicationPet.where(pet: pet_6, application: application_1).first.update(status: :rejected)
         expect(shelter_4.action_required_pets.count).to eq(1)
+        expect(shelter_4.action_required_pets).to eq([pet_7])
       end
     end
 
@@ -134,6 +135,7 @@ RSpec.describe Shelter, type: :model do
         ApplicationPet.where(pet: pet_5, application: application_1).first.update(status: :approved)
         ApplicationPet.where(pet: pet_6, application: application_1).first.update(status: :rejected)
         expect(shelter_4.action_required_applications.count).to eq(1)
+        expect(shelter_4.action_required_applications).to eq([application_1])
       end
     end
   end


### PR DESCRIPTION
This branch accomplishes the following:

-refactor the shelter model make_address_readable class method to only return a value if the shelter_id passed in as an argument returns a shelter with an `address` attribute
-refactor the shelter model action_required_applications instance method to return the correct value